### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,14 @@
 - [iTerm2](https://www.iterm2.com/)
 - [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html)
 - [Microsoft Office](https://products.office.com/en-us/mac/microsoft-office-for-mac)
-- [Tunnelblick](https://tunnelblick.net/)
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [VLC](https://www.videolan.org/vlc/index.html)
-- [Wireshark](https://www.wireshark.org/) - temporarily removed new build required to fix issue requiring Rosetta 2 see [here](https://gitlab.com/wireshark/wireshark/-/issues/17757)
+- [VLC](https://www.videolan.org/vlc/)
+- [Wireshark](https://www.wireshark.org/)
+- [balenaEthcer](https://etcher.balena.io/)
+- [Ableton Live Suite](https://www.ableton.com/)
+- [Muse Score 4](https://musescore.org/)
+- [RaspberryPi Imager](https://github.com/raspberrypi/rpi-imager)
+- [Yubikey Manager](https://www.yubico.com/support/download/yubikey-manager/)
 
 ### CLI APPS:
 - [dockutil](https://github.com/kcrawford/dockutil)
@@ -18,6 +22,7 @@
 
 ### AppStore Apps:
 - [Xcode](https://apps.apple.com/us/app/xcode/id497799835)
+- [Bitwarden](https://apps.apple.com/us/app/bitwarden-password-manager/id1137397744)
 
 ***
 


### PR DESCRIPTION
Removed warning about Wireshark as it no longer requires Rosetta 2. Added balenaEtcher, Abelton Live Suite, Bitwarden, Yubikey Manager, RaspberryPi Imager, MuseScore 4. Updated link for VLC. Removed Tunnelblick as no longer using it.